### PR TITLE
BUG FIX: Corrected Container Port Configuration in docker-compose.yml

### DIFF
--- a/docker/docker-compose.yml
+++ b/docker/docker-compose.yml
@@ -22,7 +22,7 @@ services:
     env_file:
       - .env
     ports:
-      - '2283:2283'
+      - '2283:3001'
     depends_on:
       - redis
       - database


### PR DESCRIPTION
The internal container port was incorrectly configured as 2283 instead of the correct port, 3001.